### PR TITLE
Improve Dockerfile, entrypoint, and docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.github
+.dockerignore
+renovate.json
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,14 @@ RUN : \
        -Dice=OFF \
        -DCMAKE_BUILD_TYPE=Release \
        /root/mumble/mumble-* \
-    && make -j1
+    && make -j$(nproc)
 
 # Distribution stage
 FROM debian:bookworm-slim@sha256:f06537653ac770703bc45b4b113475bd402f451e85223f0f2837acbf89ab020a
+
+LABEL org.opencontainers.image.source="https://github.com/chrisdeutsch/docker-mumble"
+LABEL org.opencontainers.image.description="Containerized Mumble VoIP server"
+LABEL org.opencontainers.image.licenses="MIT"
 
 ADD ./LICENSE /licenses/LICENSE
 ADD ./LICENSE_MUMBLE /licenses/LICENSE_MUMBLE
@@ -83,6 +87,8 @@ RUN : \
 
 USER mumble-server
 EXPOSE 64738/tcp 64738/udp
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD bash -c 'echo > /dev/tcp/localhost/64738'
 
 ADD ./entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -22,3 +22,18 @@ services:
       - "64738:64738/tcp"
       - "64738:64738/udp"
 ```
+
+## Configuration
+
+On first start, a default `mumble-server.ini` is created in the `/config` volume. Edit this file to customize the server (e.g. set a password, server name, or max users) and restart the container to apply changes.
+
+## Volumes
+
+| Path | Description |
+|---|---|
+| `/config` | Server configuration (`mumble-server.ini`) |
+| `/data` | Persistent data (SQLite database) |
+
+## Ports
+
+The server uses port **64738** for both TCP (control) and UDP (voice).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 if [[ ! -f /config/mumble-server.ini ]]; then
     sed \


### PR DESCRIPTION
## Summary

- Add `.dockerignore` to exclude `.git`, `.github`, `README.md`, and `renovate.json` from the build context
- Add OCI labels (`source`, `description`, `licenses`) to the distribution image
- Add `HEALTHCHECK` using bash's built-in `/dev/tcp` probe on port 64738 (no extra dependencies)
- Use `make -j$(nproc)` instead of `make -j1` for faster image builds
- Add `set -e` to `entrypoint.sh` so failures aren't silently ignored
- Expand README with configuration, volumes, and ports documentation

## Test plan

- [x] Image builds successfully
- [x] OCI labels verified via `docker inspect`
- [x] Healthcheck TCP probe confirmed working against running container
- [x] Entrypoint correctly generates config with database path rewrite
- [x] `.dockerignore` excludes intended files from image