### PR TITLE
Add workflow to clean up old container images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4

--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -1,0 +1,22 @@
+name: Cleanup old container images
+
+on:
+  schedule:
+    - cron: "0 3 * * 0" # Every Sunday at 03:00 UTC
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+
+    steps:
+      - name: Delete old untagged images
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
+        with:
+          package-name: mumble-server
+          package-type: container
+          min-versions-to-keep: 5
+          delete-only-untagged-versions: true


### PR DESCRIPTION
## Summary
- Adds a scheduled GitHub Actions workflow that runs weekly (Sundays at 03:00 UTC) to prune old untagged container image versions from GHCR
- Keeps the 5 most recent versions and only deletes untagged ones, so the `:latest` tag is never removed
- Also supports manual triggering via `workflow_dispatch`
- Fixes zizmor `artipacked` finding in `build.yml` by setting `persist-credentials: false` on checkout

## Test plan
- [ ] Verify the workflow appears in the Actions tab after merge
- [ ] Trigger manually via `workflow_dispatch` to confirm it runs successfully
- [ ] Confirm that only untagged versions are deleted and `:latest` is preserved